### PR TITLE
beerocks_async_work_queue.h: add missing include <functional>

### DIFF
--- a/beerocks/bcl/include/beerocks/bcl/beerocks_async_work_queue.h
+++ b/beerocks/bcl/include/beerocks/bcl/beerocks_async_work_queue.h
@@ -13,6 +13,7 @@
 #include "beerocks_thread_base.h"
 #include "beerocks_thread_safe_queue.h"
 
+#include <functional>
 #include <future>
 
 namespace beerocks {


### PR DESCRIPTION
beerocks_async_work_queue.h uses std::bind but did not include
<functional> where it is defined. This works if <functional> happens to
be included before, but we can't rely on that.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>